### PR TITLE
fix archive-all-email-recs patch to use alternative commands

### DIFF
--- a/custom/preact/archive-all-email-recs/archive-all-email-recs.sh
+++ b/custom/preact/archive-all-email-recs/archive-all-email-recs.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 for jsonFile in $(grep -rl 'snap/recommendation/email' . --include '*.json'); do
-    jsxFile="${jsonFile/.json/.jsx}"
-    scssFile="${jsonFile/.json/.scss}"
+    dir=$(dirname "$jsonFile")
+    base=$(basename "$jsonFile" .json)
+    jsxFile="$dir/$base.jsx"
+    scssFile="$dir/$base.scss"
 
     name=$(jq -r '.name' $jsonFile)
 
@@ -35,10 +37,9 @@ for jsonFile in $(grep -rl 'snap/recommendation/email' . --include '*.json'); do
         fi
 
         # remove empty directory
-        recsDir=$(dirname $jsonFile)
-        if [ -z "$(ls -A $recsDir)" ]; then
-            echo "Deleting empty directory $recsDir"
-            rm -rf $recsDir
+        if [ -z "$(ls -A $dir)" ]; then
+            echo "Deleting empty directory $dir"
+            rm -rf $dir
         fi
     else
         echo "failed to archive $name"


### PR DESCRIPTION
The string replace was not working in the Github runner. Refactored to use different commands. Tested locally and matches functionality. 